### PR TITLE
Update timestamp and sampling

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -14,6 +14,7 @@ click = ">=7.1.2"
 pandas = ">=1.2.4"
 tinker-engine = {editable = true, path = "./../tinker-engine"}
 vidaug = {editable = true, path = "./../vidaug"}
+tqdm = ">=4.60.0"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e2b7bffe8e38dbb92a982eb9ed58bde0e0b0a737b299880ce2f1b9eddb6c685a"
+            "sha256": "3c77e8d953f0bc5a9a0ba53ef3f2e9dd2c59c9d061616145deae09ac77573adc"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -210,6 +210,14 @@
             ],
             "index": "pypi",
             "version": "==0.8.2"
+        },
+        "tqdm": {
+            "hashes": [
+                "sha256:daec693491c52e9498632dfbe9ccfc4882a557f5fa08982db1b4d3adbe0887c3",
+                "sha256:ebdebdb95e3477ceea267decfc0784859aa3df3e27e22d23b83e9b272bf157ae"
+            ],
+            "index": "pypi",
+            "version": "==4.60.0"
         },
         "typing-extensions": {
             "hashes": [

--- a/TEST_COMMAND.md
+++ b/TEST_COMMAND.md
@@ -1,0 +1,33 @@
+# Activity Recognition
+
+## Class Wise Novelty
+
+### Early Test
+```
+python gen_data/gen_test.py --known_video_csv ucf101_train_knowns_revised.csv \
+                            --unknown_video_csv ucf101_train_unknowns_revised.csv \
+                            --num_groups 20 --num_runs 5 --num_samples_per_run 960 \
+                            --novelty_timestamp early --aug_type class \
+                            --output_test_dir activity-recognition/early_960-samples_20-groups_5-runs \
+                            --round_size 960 --protocol OND --seed 2192
+```
+
+### In Middle Test
+```
+python gen_data/gen_test.py --known_video_csv ucf101_train_knowns_revised.csv \
+                            --unknown_video_csv ucf101_train_unknowns_revised.csv \
+                            --num_groups 20 --num_runs 5 --num_samples_per_run 960 \
+                            --novelty_timestamp in_middle --aug_type class \
+                            --output_test_dir activity-recognition/in-middle_960-samples_20-groups_5-runs \
+                            --round_size 960 --protocol OND --seed 3192
+```
+
+### Late Test
+```
+python gen_data/gen_test.py --known_video_csv ucf101_train_knowns_revised.csv \
+                            --unknown_video_csv ucf101_train_unknowns_revised.csv \
+                            --num_groups 20 --num_runs 5 --num_samples_per_run 960 \
+                            --novelty_timestamp late --aug_type class \
+                            --output_test_dir activity-recognition/late_960-samples_20-groups_5-runs \
+                            --round_size 960 --protocol OND --seed 4192
+```

--- a/gen_data/gen_test.py
+++ b/gen_data/gen_test.py
@@ -9,6 +9,7 @@ import json
 import math
 import warnings
 import copy
+from tqdm.auto import trange
 import hashlib
 from collections import OrderedDict
 # from vidaug import augmentors as va
@@ -142,9 +143,8 @@ def gen_test(
         num_groups,
         math.ceil((num_samples_per_run - random_timestamp)
             * prob_novel_class))
-    
-    for nr in range(num_runs):
-        for ng in range(num_groups):
+    for nr in trange(num_runs, desc="Runs"):
+        for ng in trange(num_groups, desc="Groups"):
             df, metadata = create_individual_test(
                 known_video_sampling[ng], 
                 unknown_video_sampling[ng],

--- a/gen_data/gen_test.py
+++ b/gen_data/gen_test.py
@@ -127,7 +127,7 @@ def gen_test(
     np.random.seed(seed=seed)
     known_videos_dict = read_csv(known_video_csv)
     unknown_videos_dict = read_csv(unknown_video_csv)
-    assert len(known_videos_dict) > num_samples_per_run
+    assert len(known_videos_dict) >= num_samples_per_run
     upper_bound_timestamp = min(num_samples_per_run, len(known_videos_dict))
     if novelty_timestamp == "early":
         random_timestamp = np.random.randint(0, upper_bound_timestamp//3)

--- a/gen_data/gen_test.py
+++ b/gen_data/gen_test.py
@@ -127,6 +127,7 @@ def gen_test(
     np.random.seed(seed=seed)
     known_videos_dict = read_csv(known_video_csv)
     unknown_videos_dict = read_csv(unknown_video_csv)
+    assert len(known_videos_dict) > num_samples_per_run
     upper_bound_timestamp = min(num_samples_per_run, len(known_videos_dict))
     if novelty_timestamp == "early":
         random_timestamp = np.random.randint(0, upper_bound_timestamp//3)

--- a/gen_data/gen_test.py
+++ b/gen_data/gen_test.py
@@ -62,29 +62,21 @@ def sample_vids(videos, num_times_to_sample, num_samples):
     if len(videos) < (num_times_to_sample * num_samples):
         warnings.warn('Sampling more samples than have in video, will '+ 
             'have repeats')
-    
-    np.random.shuffle(videos)
-    sampled_videos = []
-    i = 0
-    num_samples = int(num_samples)
-    while len(sampled_videos) < (num_times_to_sample * num_samples):
-        if ((i+1) * num_samples) > len(videos):
-            # need to reshuffle and reset counter
-            remaining_videos = videos[i*num_samples:]
-            to_be_shuffled_videos = [x for x in videos if x not in
-                remaining_videos]
-            np.random.shuffle(to_be_shuffled_videos)
-            videos = remaining_videos + to_be_shuffled_videos
-            i = 0
-        sampled_videos.extend(videos[i*num_samples: (i+1)*num_samples])
-        i += 1
 
-    # reshape sampled videos to be of proper shape
-    sampled_videos = np.reshape(np.array(sampled_videos),
-        (num_times_to_sample, num_samples))
-
-    assert sampled_videos.shape == (num_times_to_sample, num_samples)
-    return sampled_videos
+    sampled_vids = []
+    np_videos = np.array(videos)
+    rng = np.random.default_rng()
+    current_sample_idx = 0
+    while current_sample_idx < num_times_to_sample:
+        rng.shuffle(np_videos)
+        samples = rng.choice(np_videos, size=num_samples, replace=False)
+        sampled_vids.append(samples)
+        if current_sample_idx >= num_times_to_sample:
+            break
+        current_sample_idx += 1
+    sampled_vids = np.array(sampled_vids)
+    assert sampled_vids.shape == (num_times_to_sample, num_samples)
+    return sampled_vids
 
 def gen_test(
     known_video_csv,

--- a/gen_data/gen_test.py
+++ b/gen_data/gen_test.py
@@ -52,7 +52,7 @@ def read_csv(csv_path):
         return_dict[row[0]] = int(row[1])
     return return_dict
 
-def sample_vids(videos, num_times_to_sample, num_samples):
+def sample_vids(videos, num_times_to_sample, num_samples, seed):
     """
     Sample from a list randomly, without replacement, 'num_times_to_sample'
     times. Returns a numpy array of shape (num_times_to_sample, num_samples)
@@ -66,7 +66,7 @@ def sample_vids(videos, num_times_to_sample, num_samples):
 
     sampled_vids = []
     np_videos = np.array(videos)
-    rng = np.random.default_rng()
+    rng = np.random.default_rng(seed)
     current_sample_idx = 0
     while current_sample_idx < num_times_to_sample:
         rng.shuffle(np_videos)
@@ -137,12 +137,14 @@ def gen_test(
         num_groups,
         random_timestamp +
             math.floor((num_samples_per_run - random_timestamp) 
-            * (1-prob_novel_class)))
+            * (1-prob_novel_class)),
+        seed)
 
     unknown_video_sampling = sample_vids(unknown_videos,
         num_groups,
         math.ceil((num_samples_per_run - random_timestamp)
-            * prob_novel_class))
+            * prob_novel_class),
+        seed)
     for nr in trange(num_runs, desc="Runs"):
         for ng in trange(num_groups, desc="Groups"):
             df, metadata = create_individual_test(

--- a/gen_data/gen_test.py
+++ b/gen_data/gen_test.py
@@ -66,11 +66,18 @@ def sample_vids(videos, num_times_to_sample, num_samples, seed):
 
     sampled_vids = []
     np_videos = np.array(videos)
+    video_idx = np.array(range(len(np_videos)))
     rng = np.random.default_rng(seed)
     current_sample_idx = 0
     while current_sample_idx < num_times_to_sample:
-        samples = rng.choice(np_videos, size=num_samples, replace=False)
-        sampled_vids.append(samples)
+        try:
+            sample_idx = rng.choice(video_idx, size=num_samples, replace=False)
+            video_idx = np.setdiff1d(video_idx, sample_idx)
+        except ValueError:
+            # Recreate numpy array for videos for resampling
+            video_idx = np.array(range(len(np_videos)))
+            continue
+        sampled_vids.append(np_videos[sample_idx])
         if current_sample_idx >= num_times_to_sample:
             break
         current_sample_idx += 1

--- a/gen_data/gen_test.py
+++ b/gen_data/gen_test.py
@@ -69,7 +69,6 @@ def sample_vids(videos, num_times_to_sample, num_samples, seed):
     rng = np.random.default_rng(seed)
     current_sample_idx = 0
     while current_sample_idx < num_times_to_sample:
-        rng.shuffle(np_videos)
         samples = rng.choice(np_videos, size=num_samples, replace=False)
         sampled_vids.append(samples)
         if current_sample_idx >= num_times_to_sample:

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ torchvision==0.8.2
 av>=8.0.2
 click>=7.1.2
 pandas>=1.2.4
+tqdm>=4.60.0


### PR DESCRIPTION
This PR changes the timestamp to a string with 3 choices rather than a number. This allows test generation without specifying an exact point where novelty is introduced. Additionally, it uses np.random.choice for sampling rather than looping and uses tqdm for ease of visualization